### PR TITLE
chore: simplifying imagePullPolicy with property

### DIFF
--- a/apps/hello-kubernetes/pom.xml
+++ b/apps/hello-kubernetes/pom.xml
@@ -19,6 +19,7 @@
 		<jkube.build.strategy>jib</jkube.build.strategy>
 		<jkube.generator.name>quay.io/sunix/sb-hw:${project.version}</jkube.generator.name>
 		<jkube.createExternalUrls>true</jkube.createExternalUrls>
+		<jkube.enricher.jkube-controller.pullPolicy>Always</jkube.enricher.jkube-controller.pullPolicy>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -82,11 +83,6 @@
 				<groupId>org.eclipse.jkube</groupId>
 				<artifactId>kubernetes-maven-plugin</artifactId>
 				<version>1.8.0</version>
-				<configuration>
-					<resources>
-						<imagePullPolicy>Always</imagePullPolicy>
-					</resources>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/documentation/modules/ROOT/pages/03-kubernetes.adoc
+++ b/documentation/modules/ROOT/pages/03-kubernetes.adoc
@@ -18,7 +18,9 @@ Open `pom.xml` file and add the following properties at `<properties>` section:
 <jkube.build.strategy>jib</jkube.build.strategy>
 <jkube.generator.name>quay.io/sunix/sb-hw:${project.version}</jkube.generator.name>
 <jkube.createExternalUrls>true</jkube.createExternalUrls>
+<jkube.enricher.jkube-controller.pullPolicy>Always</jkube.enricher.jkube-controller.pullPolicy> <!--1-->
 ----
+<1> Configures `imagePullPolicy` attribute
 
 IMPORTANT: Substitute `quay.io` for your container registry and `sunix` with your username.
 
@@ -32,14 +34,9 @@ Then add the `jkube` plugin at `plugins` section just after the `spring-boot-mav
 	<groupId>org.eclipse.jkube</groupId>
 	<artifactId>kubernetes-maven-plugin</artifactId>
 	<version>1.8.0</version>
-  <configuration>
-		<resources>
-			<imagePullPolicy>Always</imagePullPolicy> <!--1-->
-		</resources>
-	</configuration>
 </plugin>
 ----
-<1> Configures `imagePullPolicy` attribute
+
 
 Login into container registry running:
 


### PR DESCRIPTION
This is simplifying the option to Always pull the image (useful when pushing new image of the same version) by using the property rather the xml config.
Although there is a bug when setting the pull policy via property (see https://github.com/eclipse/jkube/issues/1619) it should not be an issue in the flow of this course as the `src/main/jkube/deployment.yml` is added at the end.
